### PR TITLE
Pass props through to original component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ coverage
 
 # Build
 dist
+
+# Editor artifacts
+.idea

--- a/src/index.js
+++ b/src/index.js
@@ -319,7 +319,7 @@ export default (experimentName) =>
    *         The wrapped component
    */
   (Component) =>
-    () => {
+    (props) => {
       // Activate the experiment
       const isActive = activate(experimentName)
 
@@ -328,5 +328,6 @@ export default (experimentName) =>
       const variant = getVariant(experimentName)
 
       return <Component
+        {...props}
         optimizely={{ experiment, variant, isActive }} />
     }

--- a/test/connect.js
+++ b/test/connect.js
@@ -124,3 +124,34 @@ test('connect: activated and experiment', (t) => {
   })
   t.is(frame.props.optimizely.isActive, true)
 })
+
+test('connect: props pass-through', (t) => {
+  global.window = mockOptimizelyWindow({
+    allExperiments: {
+      'A': {
+        name: 'Experiment A',
+        enabled: true
+      }
+    },
+    variationMap: {
+      'A': {
+        'name': 'Variant A',
+        'code': 'JSCODE'
+      }
+    },
+    activeExperiments: ['A'],
+    push: ([method, ...args]) => {
+      if (method === 'activate') {
+        window.optimizely.activeExperiments = window.optimizely.activeExperiments || []
+        window.optimizely.activeExperiments.push(args[0])
+      }
+    }
+  })
+
+  const renderer = createRenderer(
+    connect('Experiment A')(TestComponent)
+  )
+  let frame = renderer.render({ other: 'props' })
+
+  t.is(frame.props.other, 'props')
+})


### PR DESCRIPTION
If using `optimizely` as a HOC, props being passed into the wrapped component ought to pass through to the original component. This behavior brings it more in line to similar HOCs, like react-redux.